### PR TITLE
use token as key, instead of constant "copilotToken"

### DIFF
--- a/cf_copilot_service.js
+++ b/cf_copilot_service.js
@@ -126,7 +126,7 @@ async function streamResponse(openAIResponse, writable, requestData) {
 }
 
 async function getCopilotToken(githubToken) {
-  let tokenData = await GithubCopilotChat.get("copilotToken", "json");
+  let tokenData = await GithubCopilotChat.get(githubToken, "json");
   
   if (tokenData && tokenData.expires_at * 1000 > Date.now()) {
     return tokenData.token;
@@ -148,7 +148,7 @@ async function getCopilotToken(githubToken) {
 
   const data = await response.json();
 
-  await GithubCopilotChat.put("copilotToken", JSON.stringify({ token: data.token, expires_at: data.expires_at }), {
+  await GithubCopilotChat.put(githubToken, JSON.stringify({ token: data.token, expires_at: data.expires_at }), {
     expirationTtl: data.expires_at
   });
 


### PR DESCRIPTION
现在使用copilotToken作为key的话，在它过期之前，其他知道接口的人可以使用任意非空字符串作为token使用该接口。
用githubToken作为key可以避免这个问题，同时不同的人可以使用不同的token。